### PR TITLE
test: stabilize speaker e2e waits

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,6 @@
 # 최선화닷컴 — 작업 현황판
 
-> 기준: 2026-06-06 18:08 KST / QA 운영 E2E 완료 기준
+> 기준: 2026-06-06 21:36 KST / QA 운영 E2E PR 리뷰 기준
 > 배포는 Vercel CLI 금지. `git push origin main` 자동 배포만 사용.
 
 ---
@@ -115,7 +115,7 @@ GitHub connector 기준 열린 이슈는 운영 설정/QA 검증만 남겼다.
 - open 잔여 권장: `#5` Auth 운영 검증 잔여, `#19` 어드민/OAuth E2E, `#21` Google OAuth 운영 설정
 - QA 완료 확인: `#16` E2E 문의 플로우, `#17` E2E 탐색 플로우는 운영 E2E 통과
 - closed: 코드/현황판 기준 구현 완료 이슈 `#1`~`#4`, `#6`~`#15`, `#18`, `#20`, `#22`
-- 열린 PR은 없음
+- 최근 PR: `#25` T-003 E2E 안정화 리뷰 완료
 
 이슈 상태는 이제 코드 완료분과 운영/QA 잔여분을 분리한 상태다.
 
@@ -139,8 +139,8 @@ GitHub connector 기준 열린 이슈는 운영 설정/QA 검증만 남겼다.
 ## 다음 액션
 
 1. Scott: `docs/google-oauth-ops.md` 기준 운영 Google OAuth Provider/Google Console 설정 확인
-2. @dev: #16/#17 이슈 종료 및 QA 안정화 PR 병합
+2. @dev: #16/#17 이슈 종료
 
 ---
 
-_최종 업데이트: 2026-06-06 18:08 KST | 업데이트 담당: @qa_cshdotcom_bot_
+_최종 업데이트: 2026-06-06 21:36 KST | 업데이트 담당: @dev_cshdotcom_bot_

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,6 @@
 # 최선화닷컴 — 작업 현황판
 
-> 기준: 2026-06-06 17:27 KST / heartbeat 정리 기준
+> 기준: 2026-06-06 18:08 KST / QA 운영 E2E 완료 기준
 > 배포는 Vercel CLI 금지. `git push origin main` 자동 배포만 사용.
 
 ---
@@ -9,11 +9,10 @@
 
 MVP 기능은 대부분 구현 완료. 공개 사이트, 어드민, 매칭, 인사이트, 추천 강사, 트렌드 브리핑 자동화까지 `main`에 반영되어 있다.
 
-현재 남은 핵심은 운영 안정화다.
+운영 배포 기준 E2E 전체 재검증은 통과했다. 현재 남은 핵심은 Google OAuth 운영 설정 확인이다.
 
 1. Google OAuth 운영 설정/검증
-2. E2E 전체 재검증
-3. GitHub 이슈 잔여 항목 운영/QA 검증
+2. GitHub 이슈 잔여 항목 운영/QA 검증
 
 ---
 
@@ -27,7 +26,8 @@ MVP 기능은 대부분 구현 완료. 공개 사이트, 어드민, 매칭, 인�
 | 유닛 테스트 | ✅ | `npm test -- --run` → 36/36 통과 |
 | lint | ✅ | `npm run lint` → 0 errors / 19 warnings, exit 0 |
 | production build | ✅ | `npm run build` → 통과. Next middleware deprecation warning만 잔존 |
-| GitHub issue 정리 | ✅ | 완료 구현 이슈 close. open: #5, #16, #17, #19, #21 |
+| 운영 E2E | ✅ | `PLAYWRIGHT_BASE_URL=https://choisunhwa-dot-com.vercel.app npm run test:e2e` → 66 passed / 2 skipped |
+| GitHub issue 정리 | ✅ | 완료 구현 이슈 close. #16/#17 운영 E2E 통과 확인. 잔여 open: #5, #19, #21 |
 | GitHub CLI | ⚠️ | 로컬 `gh` 미로그인. GitHub connector로 확인 |
 | GitHub Actions | ⚠️ | `gh` 미로그인으로 run 상태 직접 확인 불가 |
 
@@ -102,7 +102,7 @@ MVP 기능은 대부분 구현 완료. 공개 사이트, 어드민, 매칭, 인�
 | 우선순위 | 항목 | 담당 | 상태 | 메모 |
 |----------|------|------|------|------|
 | P0 | Vercel 환경변수/최신 배포 확인 | @dev | ✅ 완료 | `48002cc` Vercel success, 운영 스모크 PASS |
-| P0 | E2E 전체 재실행 | @qa | 🟡 진행 요청 | T-004 완료 후 QA 인계 |
+| P0 | E2E 전체 재실행 | @qa | ✅ 완료 | 운영 Playwright E2E 66 passed / 2 skipped |
 | P1 | Google OAuth 운영 설정 | @backend/Scott | 🟡 Scott 확인 필요 | 코드 경로/프로필 생성 확인, Supabase Provider/Google Console 운영값 확인 필요 |
 | P2 | STATUS/TASKS 운영 규칙 정리 | @dev | 🟡 필요 | 상태판과 GitHub issue를 한 기준으로 맞춰야 함 |
 
@@ -112,7 +112,8 @@ MVP 기능은 대부분 구현 완료. 공개 사이트, 어드민, 매칭, 인�
 
 GitHub connector 기준 열린 이슈는 운영 설정/QA 검증만 남겼다.
 
-- open: `#5` Auth 운영 검증 잔여, `#16` E2E 문의 플로우, `#17` E2E 탐색 플로우, `#19` 어드민/OAuth E2E, `#21` Google OAuth 운영 설정
+- open 잔여 권장: `#5` Auth 운영 검증 잔여, `#19` 어드민/OAuth E2E, `#21` Google OAuth 운영 설정
+- QA 완료 확인: `#16` E2E 문의 플로우, `#17` E2E 탐색 플로우는 운영 E2E 통과
 - closed: 코드/현황판 기준 구현 완료 이슈 `#1`~`#4`, `#6`~`#15`, `#18`, `#20`, `#22`
 - 열린 PR은 없음
 
@@ -137,9 +138,9 @@ GitHub connector 기준 열린 이슈는 운영 설정/QA 검증만 남겼다.
 
 ## 다음 액션
 
-1. @qa: 운영 배포 기준 E2E 전체 실행
-2. Scott: `docs/google-oauth-ops.md` 기준 운영 Google OAuth Provider/Google Console 설정 확인
+1. Scott: `docs/google-oauth-ops.md` 기준 운영 Google OAuth Provider/Google Console 설정 확인
+2. @dev: #16/#17 이슈 종료 및 QA 안정화 PR 병합
 
 ---
 
-_최종 업데이트: 2026-06-06 17:27 KST | 업데이트 담당: @dev_cshdotcom_bot_
+_최종 업데이트: 2026-06-06 18:08 KST | 업데이트 담당: @qa_cshdotcom_bot_

--- a/TASKS.md
+++ b/TASKS.md
@@ -108,6 +108,11 @@
   - 회귀 확인: `npx playwright test src/tests/e2e/speakers.spec.ts --project=chromium` PASS 12/12
   - 최종 운영 E2E: `PLAYWRIGHT_BASE_URL=https://choisunhwa-dot-com.vercel.app npm run test:e2e` PASS 66/66, skipped 2
   - lint: PASS (0 errors / 19 warnings)
+
+[2026-06-06] @dev PR #25 리뷰
+  - 코드 리뷰: `networkidle` 제거와 DOM 기준 대기 전환 승인
+  - Gemini 리뷰 코멘트 반영: `expectSpeakerResultsVisible` 중복 href 조회 제거
+  - 재검증: speakers chromium E2E 12/12 PASS, lint 0 errors / 19 warnings
 ```
 
 ---

--- a/TASKS.md
+++ b/TASKS.md
@@ -16,7 +16,6 @@
 | ID | 우선순위 | assignee | 제목 | 시작일 | 메모 |
 |----|---------|----------|------|--------|------|
 | T-019 | P1 | @backend/Scott | Google OAuth 운영 설정 검증 (Supabase Provider + Client ID/Secret + profiles) | 2026-05-29 | 코드 경로 수정 완료. Supabase Dashboard/Google Console 운영값은 Scott 확인 필요 |
-| T-003 | P0 | @qa | E2E 전체 실행 + 버그 리포트 | 2026-02-25 | T-004 완료. E2E 재개 요청 전송 |
 
 ---
 
@@ -42,6 +41,7 @@
 | T-016 | @dev | lint 실패 47 errors 정리 | 2026-06-06 | `npm run lint`: 0 errors / 19 warnings, exit 0. `npm test -- --run`: 36/36 PASS |
 | T-018 | @dev | GitHub 이슈 상태 정리 (#1~#22) | 2026-06-06 | closed #1~#4, #6~#15, #18, #20, #22. open #5, #16, #17, #19, #21 |
 | T-004 | @dev | Vercel 환경변수 설정 + 최신 배포 상태 확인 | 2026-06-06 | Vercel check success on 48002cc, 운영 스모크 PASS, QA 인계 |
+| T-003 | @qa | E2E 전체 실행 + 버그 리포트 | 2026-06-06 | 운영 Playwright E2E 66 passed / 2 skipped. `networkidle` 의존 제거로 speakers E2E 안정화 |
 
 ---
 
@@ -100,6 +100,14 @@
   - `/api/cron/trend-briefing`: 무인증 401 확인 → CRON_SECRET 적용 상태로 판단
   - GitHub commit status: 48002cc Vercel success 확인
   - T-004 done 처리, QA에게 E2E 재개 요청
+
+[2026-06-06] @qa T-003 운영 E2E 완료
+  - 최초 운영 E2E: 60 passed / 2 skipped / 6 failed
+  - 실패 원인: 기능 장애가 아니라 chromium desktop에서 `page.waitForLoadState('networkidle')`가 장기 요청 때문에 timeout
+  - 수정: speakers E2E를 사용자 가시 DOM 기준 대기로 변경 (`domcontentloaded` + 강사 상세 링크 렌더링)
+  - 회귀 확인: `npx playwright test src/tests/e2e/speakers.spec.ts --project=chromium` PASS 12/12
+  - 최종 운영 E2E: `PLAYWRIGHT_BASE_URL=https://choisunhwa-dot-com.vercel.app npm run test:e2e` PASS 66/66, skipped 2
+  - lint: PASS (0 errors / 19 warnings)
 ```
 
 ---

--- a/src/tests/e2e/speakers.spec.ts
+++ b/src/tests/e2e/speakers.spec.ts
@@ -20,12 +20,16 @@ async function getSpeakerDetailHrefs(page: Page): Promise<string[]> {
 async function expectSpeakerResultsVisible(page: Page): Promise<string[]> {
   await expect(page.getByRole('heading', { name: /강사/i })).toBeVisible()
 
+  let hrefs: string[] = []
   await expect.poll(
-    () => getSpeakerDetailHrefs(page).then((hrefs) => hrefs.length),
+    async () => {
+      hrefs = await getSpeakerDetailHrefs(page)
+      return hrefs.length
+    },
     { timeout: 10000 }
   ).toBeGreaterThan(0)
 
-  return getSpeakerDetailHrefs(page)
+  return hrefs
 }
 
 test.describe('강사 소개 리스트', () => {

--- a/src/tests/e2e/speakers.spec.ts
+++ b/src/tests/e2e/speakers.spec.ts
@@ -3,7 +3,30 @@
  * QA: 한큐
  */
 
-import { test, expect } from '@playwright/test'
+import { test, expect, type Page } from '@playwright/test'
+
+const SPEAKER_DETAIL_HREF_PATTERN =
+  '^/speakers/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+
+async function getSpeakerDetailHrefs(page: Page): Promise<string[]> {
+  return page.locator('a[href^="/speakers/"]').evaluateAll((links, pattern) => {
+    const hrefPattern = new RegExp(pattern)
+    return links
+      .map((link) => link.getAttribute('href'))
+      .filter((href): href is string => Boolean(href && hrefPattern.test(href)))
+  }, SPEAKER_DETAIL_HREF_PATTERN)
+}
+
+async function expectSpeakerResultsVisible(page: Page): Promise<string[]> {
+  await expect(page.getByRole('heading', { name: /강사/i })).toBeVisible()
+
+  await expect.poll(
+    () => getSpeakerDetailHrefs(page).then((hrefs) => hrefs.length),
+    { timeout: 10000 }
+  ).toBeGreaterThan(0)
+
+  return getSpeakerDetailHrefs(page)
+}
 
 test.describe('강사 소개 리스트', () => {
   test.beforeEach(async ({ page }) => {
@@ -77,37 +100,17 @@ test.describe('BUG-N-014: 인사이트 태그 → 강사 필터 alias 라우팅'
 
   for (const { tag, expectedField } of aliasCases) {
     test(`"${tag}" 태그 → ${expectedField} 강사 목록 1명 이상 표시`, async ({ page }) => {
-      await page.goto(`/speakers?category=${encodeURIComponent(tag)}`)
-      await page.waitForLoadState('networkidle')
+      await page.goto(`/speakers?category=${encodeURIComponent(tag)}`, { waitUntil: 'domcontentloaded' })
 
-      // SpeakerList 카드는 <Link href="/speakers/[uuid]"> (= <a>) 구조
-      // UUID 형식 href (/speakers/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) 로 정확히 매칭
-      const speakerCardLinks = await page.$$('a[href]')
-      let count = 0
-      for (const el of speakerCardLinks) {
-        const href = await el.getAttribute('href')
-        if (href && /^\/speakers\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(href)) {
-          count++
-        }
-      }
-
-      expect(count).toBeGreaterThan(0)
+      const speakerHrefs = await expectSpeakerResultsVisible(page)
+      expect(speakerHrefs.length).toBeGreaterThan(0)
     })
   }
 
   test('같은 alias 그룹은 동일 강사 세트 반환 — MZ세대=조직문화(HR)', async ({ page }) => {
     async function getSpeakerHrefs(tag: string): Promise<string[]> {
-      await page.goto(`/speakers?category=${encodeURIComponent(tag)}`)
-      await page.waitForLoadState('networkidle')
-      const all = await page.$$('a[href]')
-      const hrefs: string[] = []
-      for (const el of all) {
-        const href = await el.getAttribute('href')
-        if (href && /^\/speakers\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(href)) {
-          hrefs.push(href)
-        }
-      }
-      return hrefs
+      await page.goto(`/speakers?category=${encodeURIComponent(tag)}`, { waitUntil: 'domcontentloaded' })
+      return expectSpeakerResultsVisible(page)
     }
 
     const mzHrefs  = await getSpeakerHrefs('MZ세대')
@@ -122,8 +125,7 @@ test.describe('BUG-N-014: 인사이트 태그 → 강사 필터 alias 라우팅'
 test.describe('내비게이션', () => {
   test('헤더 네비게이션이 데스크탑에서 표시된다', async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 800 })
-    await page.goto('/')
-    await page.waitForLoadState('networkidle')
+    await page.goto('/', { waitUntil: 'domcontentloaded' })
     // 리디자인 후 (2026-03): aria-label 제거됨
     // nav는 <nav class="hidden md:flex"> 형태 — header 내부 nav로 셀렉팅
     const nav = page.locator('header nav')
@@ -132,8 +134,7 @@ test.describe('내비게이션', () => {
 
   test('홈 페이지에서 강사 섹션 링크가 동작한다', async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 800 })
-    await page.goto('/')
-    await page.waitForLoadState('networkidle')
+    await page.goto('/', { waitUntil: 'domcontentloaded' })
     const speakersLink = page.getByRole('link', { name: /강사/i }).first()
     if (await speakersLink.isVisible()) {
       await speakersLink.click()


### PR DESCRIPTION
## Summary
- Stabilize speaker E2E waits by replacing `networkidle` waits with DOM-visible speaker result checks
- Record T-003 production E2E completion in STATUS.md and TASKS.md

## Verification
- `PLAYWRIGHT_BASE_URL=https://choisunhwa-dot-com.vercel.app npx playwright test src/tests/e2e/speakers.spec.ts --project=chromium` → 12 passed
- `PLAYWRIGHT_BASE_URL=https://choisunhwa-dot-com.vercel.app npm run test:e2e` → 66 passed / 2 skipped
- `npm run lint` → 0 errors / 19 warnings